### PR TITLE
Add keep-alive health check and server ping

### DIFF
--- a/.github/workflows/keep-alive.yml
+++ b/.github/workflows/keep-alive.yml
@@ -1,0 +1,15 @@
+name: Keep Server Alive
+
+on:
+  schedule:
+    # Run every 2 minutes
+    - cron: '*/2 * * * *'
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping Server
+        run: |
+          curl -f https://ai-cooking-app.onrender.com/health || echo "Ping failed"

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -38,6 +38,11 @@ def create_app(config_name=None):
     from .routes.auth import auth_bp
     app.register_blueprint(recipes_bp, url_prefix="/api/recipes")
     app.register_blueprint(auth_bp)
+    
+    # Simple health check endpoint
+    @app.route('/health', methods=['GET'])
+    def health():
+        return {'status': 'healthy', 'message': 'SnackHack API is running'}
 
     return app
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -44,6 +44,32 @@ function AppContent() {
   
   const { user, loading: authLoading, getAuthHeaders } = useAuth();
 
+  // Keep-alive ping to prevent server spin-down
+  useEffect(() => {
+    const pingServer = async () => {
+      try {
+        await fetch(`${config.API_BASE_URL}/health`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json'
+          }
+        });
+        console.log('Server ping successful');
+      } catch (error) {
+        console.log('Server ping failed:', error.message);
+      }
+    };
+
+    // Ping immediately
+    pingServer();
+
+    // Set up interval to ping every 2 minutes (120000ms)
+    const pingInterval = setInterval(pingServer, 120000);
+
+    // Cleanup interval on component unmount
+    return () => clearInterval(pingInterval);
+  }, []);
+
   // Save state to localStorage whenever it changes
   useEffect(() => {
     localStorage.setItem('app_ingredients', JSON.stringify(ingredients));


### PR DESCRIPTION
Introduces a health check endpoint to the backend and a keep-alive workflow in GitHub Actions to periodically ping the server, preventing it from spinning down. The frontend now also pings the health endpoint every 2 minutes to help keep the server active.